### PR TITLE
Pass kwargs to search parameters to enable better control

### DIFF
--- a/src/pyzenodo3/base.py
+++ b/src/pyzenodo3/base.py
@@ -77,14 +77,14 @@ class Zenodo:
         self._api_key = api_key
         self.re_github_repo = re.compile(r".*github.com/(.*?/.*?)[/$]")
 
-    def search(self, search: str) -> list[Record]:
+    def search(self, search: str, **kwargs) -> list[Record]:
         """search Zenodo record for string `search`
 
         :param search: string to search
         :return: Record[] results
         """
         search = search.replace("/", " ")  # zenodo can't handle '/' in search query
-        params = {"q": search}
+        params = {"q": search, **kwargs}
 
         recs = self._get_records(params)
 


### PR DESCRIPTION
Currently, the pyzenodo3 API only allows for a search string to be passed to search for records, while other parameters are left at their defaults. https://developers.zenodo.org/#representation (search for "List all depositions for the currently authenticated user") documents them, and it's sometimes useful to tweak the values:
![image](https://user-images.githubusercontent.com/13209176/129268705-e4a6312e-ae7e-49c8-9130-d1ecc2f1628f.png)

This PR enables the passing of these parameters to the search query.

### Example:
```py
from pyzenodo3.base import Zenodo

token = os.getenv("ZENODO_TOKEN", None)
zenodo_client = Zenodo(api_key=token, base_url="https://zenodo.org/api/")

zenodo_client.search('NSLS-II collection conda environment', size=10, sort='bestmatch', all_versions=True)
```
This is the formatted output from this search (using my helper function [`search_records`](https://github.com/mrakitin/profile_zenodo/blob/008d320ca3dd4cd47009a9c5225422ccba1da08a/startup/00-base.py#L11-L44)):
```py
In [9]: r = search_records('NSLS-II collection conda environment', size=10, sort='bestmatch', all_versions=True)
        ids  titles                          versions       files                                         checksums                             dates
--  -------  ------------------------------  -------------  --------------------------------------------  ------------------------------------  ----------
 0  4421838  NSLS-II collection conda        2021-1.2       collection-2021-1.2-sha256sum.txt             md5:6322c91bd7a248c7309c7224e5e98b0e  2021-03-19
             environment                                    collection-2021-1.2.tar.gz                    md5:b1bd9cf6660cc7527ec708f60e396813
                                                            collection-2021-1.2.yml                       md5:7a903ae0a749675d54d4c19f78d2ca5d
 1  4421721  NSLS-II collection conda        2021-1.0       collection-2020-2.0rc8.tar.gz                 md5:db8fb77565afaa7a4c75ddcf4c5f839b  2021-01-06
             environment                                    collection-2020-2.0rc9.tar.gz                 md5:ffa1b683da9e3dcd4c051ec7341ff158
                                                            collection-2021-1.0-sha256sum.txt             md5:55061c0ddd41206cd345f91c140487b9
                                                            collection-2021-1.0.tar.gz                    md5:12fa67ad0ed60bc7eeac8a2765109ab4
                                                            collection-2021-1.0.yml                       md5:2c701a6592f60ed9b986ad9fe42fcee2
 2  5171435  NSLS-II collection conda        2021-2.1       Dockerfile                                    md5:32ae4996613d572ac16193ad73a66e41  2021-08-08
             environment 2021-2.1 with                      nsls2-collection-2021-2.1-md5sum.txt          md5:5a2f4819689d164763a851b44ebacac3
             Python 3.7 (from conda-forge)                  nsls2-collection-2021-2.1-sha256sum.txt       md5:4008bafd36a95fab06dde8cd4dc46cca
                                                            nsls2-collection-2021-2.1.tar.gz              md5:1ade29372cb71c2f890c683436e0a1f1
                                                            nsls2-collection-2021-2.1.yml                 md5:1a3e57cb0378d454dd0a83c9462bdbfe
                                                            runner-nsls2-collection-2021-2.1.sh           md5:762fce84ecbd9a44102699cbd8aebcdb
 3  5140516  NSLS-II collection conda        2021-2.0       Dockerfile                                    md5:7e887ac86eb85f2adfde95d2bac6ae6d  2021-08-07
             environment 2021-2.0 (from                     nsls2-collection-2021-2.0-md5sum.txt          md5:3d0a26120b66e8110c2367b3a857eec5
             conda-forge)                                   nsls2-collection-2021-2.0-sha256sum.txt       md5:513f8a1564837a2f45d16ae5a96bb960
                                                            nsls2-collection-2021-2.0.tar.gz              md5:24a8f4ca295242b79c124f1ea15d7a3e
                                                            nsls2-collection-2021-2.0.yml                 md5:292683b6dfce116546f55d0bb90b33cb
                                                            runner-nsls2-collection-2021-2.0.sh           md5:02a1fb578bc295980167563859f7430d
 4  5171468  NSLS-II collection conda        2021-2.1-py39  Dockerfile                                    md5:6cb27f599ceb58dbad7239e86978b420  2021-08-08
             environment 2021-2.1 with                      nsls2-collection-2021-2.1-py39-md5sum.txt     md5:8e95aa7cfbfdd4f0f66854fa0b37d96d
             Python 3.9 (from conda-forge)                  nsls2-collection-2021-2.1-py39-sha256sum.txt  md5:35cac76f6db517e1729c471d23f9de5b
                                                            nsls2-collection-2021-2.1-py39.tar.gz         md5:f860379ba5854c0d8f8a4b9bdda83572
                                                            nsls2-collection-2021-2.1-py39.yml            md5:3b6a89c3b737edb00d25c506177ea412
                                                            runner-nsls2-collection-2021-2.1-py39.sh      md5:b80aaa12187991888a00a7ec4ad7ac64
 5  5168477  NSLS-II collection conda        2021-2.0-py39  Dockerfile                                    md5:8d66838062d3f56d6d3c44240a32e07f  2021-08-07
             environment 2021-2.0 with                      nsls2-collection-2021-2.0-py39-md5sum.txt     md5:d06d6e140aa1779666f3522c51476983
             Python 3.9 (from conda-forge)                  nsls2-collection-2021-2.0-py39-sha256sum.txt  md5:e77033f076030a1425f7c89cb290e78b
                                                            nsls2-collection-2021-2.0-py39.tar.gz         md5:2d70459363768f34adc94c3931549573
                                                            nsls2-collection-2021-2.0-py39.yml            md5:e652e81c621884d22904c402ac0ff57e
                                                            runner-nsls2-collection-2021-2.0-py39.sh      md5:ed0889916411ed65044bdde8420779a4
..........
```